### PR TITLE
feat: Optimize SMT implementation

### DIFF
--- a/c/ckb_smt.h
+++ b/c/ckb_smt.h
@@ -7,6 +7,217 @@
 #ifndef _CKB_SPARSE_MERKLE_TREE_H_
 #define _CKB_SPARSE_MERKLE_TREE_H_
 
+// The faster version of memset & memcpy implementations used here are from
+// the awesome musl libc project: https://www.musl-libc.org/
+void *_smt_fast_memset(void *dest, int c, size_t n)
+{
+	unsigned char *s = dest;
+	size_t k;
+
+	/* Fill head and tail with minimal branching. Each
+	 * conditional ensures that all the subsequently used
+	 * offsets are well-defined and in the dest region. */
+
+	if (!n) return dest;
+	s[0] = c;
+	s[n-1] = c;
+	if (n <= 2) return dest;
+	s[1] = c;
+	s[2] = c;
+	s[n-2] = c;
+	s[n-3] = c;
+	if (n <= 6) return dest;
+	s[3] = c;
+	s[n-4] = c;
+	if (n <= 8) return dest;
+
+	/* Advance pointer to align it at a 4-byte boundary,
+	 * and truncate n to a multiple of 4. The previous code
+	 * already took care of any head/tail that get cut off
+	 * by the alignment. */
+
+	k = -(uintptr_t)s & 3;
+	s += k;
+	n -= k;
+	n &= -4;
+
+#ifdef __GNUC__
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	typedef uint64_t __attribute__((__may_alias__)) u64;
+
+	u32 c32 = ((u32)-1)/255 * (unsigned char)c;
+
+	/* In preparation to copy 32 bytes at a time, aligned on
+	 * an 8-byte bounary, fill head/tail up to 28 bytes each.
+	 * As in the initial byte-based head/tail fill, each
+	 * conditional below ensures that the subsequent offsets
+	 * are valid (e.g. !(n<=24) implies n>=28). */
+
+	*(u32 *)(s+0) = c32;
+	*(u32 *)(s+n-4) = c32;
+	if (n <= 8) return dest;
+	*(u32 *)(s+4) = c32;
+	*(u32 *)(s+8) = c32;
+	*(u32 *)(s+n-12) = c32;
+	*(u32 *)(s+n-8) = c32;
+	if (n <= 24) return dest;
+	*(u32 *)(s+12) = c32;
+	*(u32 *)(s+16) = c32;
+	*(u32 *)(s+20) = c32;
+	*(u32 *)(s+24) = c32;
+	*(u32 *)(s+n-28) = c32;
+	*(u32 *)(s+n-24) = c32;
+	*(u32 *)(s+n-20) = c32;
+	*(u32 *)(s+n-16) = c32;
+
+	/* Align to a multiple of 8 so we can fill 64 bits at a time,
+	 * and avoid writing the same bytes twice as much as is
+	 * practical without introducing additional branching. */
+
+	k = 24 + ((uintptr_t)s & 4);
+	s += k;
+	n -= k;
+
+	/* If this loop is reached, 28 tail bytes have already been
+	 * filled, so any remainder when n drops below 32 can be
+	 * safely ignored. */
+
+	u64 c64 = c32 | ((u64)c32 << 32);
+	for (; n >= 32; n-=32, s+=32) {
+		*(u64 *)(s+0) = c64;
+		*(u64 *)(s+8) = c64;
+		*(u64 *)(s+16) = c64;
+		*(u64 *)(s+24) = c64;
+	}
+#else
+	/* Pure C fallback with no aliasing violations. */
+	for (; n; n--, s++) *s = c;
+#endif
+
+	return dest;
+}
+
+void *_smt_fast_memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+	unsigned char *d = dest;
+	const unsigned char *s = src;
+
+#ifdef __GNUC__
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define LS >>
+#define RS <<
+#else
+#define LS <<
+#define RS >>
+#endif
+
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	uint32_t w, x;
+
+	for (; (uintptr_t)s % 4 && n; n--) *d++ = *s++;
+
+	if ((uintptr_t)d % 4 == 0) {
+		for (; n>=16; s+=16, d+=16, n-=16) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			*(u32 *)(d+8) = *(u32 *)(s+8);
+			*(u32 *)(d+12) = *(u32 *)(s+12);
+		}
+		if (n&8) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			d += 8; s += 8;
+		}
+		if (n&4) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			d += 4; s += 4;
+		}
+		if (n&2) {
+			*d++ = *s++; *d++ = *s++;
+		}
+		if (n&1) {
+			*d = *s;
+		}
+		return dest;
+	}
+
+	if (n >= 32) switch ((uintptr_t)d % 4) {
+	case 1:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 3;
+		for (; n>=17; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+1);
+			*(u32 *)(d+0) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+5);
+			*(u32 *)(d+4) = (x LS 24) | (w RS 8);
+			x = *(u32 *)(s+9);
+			*(u32 *)(d+8) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+13);
+			*(u32 *)(d+12) = (x LS 24) | (w RS 8);
+		}
+		break;
+	case 2:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 2;
+		for (; n>=18; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+2);
+			*(u32 *)(d+0) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+6);
+			*(u32 *)(d+4) = (x LS 16) | (w RS 16);
+			x = *(u32 *)(s+10);
+			*(u32 *)(d+8) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+14);
+			*(u32 *)(d+12) = (x LS 16) | (w RS 16);
+		}
+		break;
+	case 3:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		n -= 1;
+		for (; n>=19; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+3);
+			*(u32 *)(d+0) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+7);
+			*(u32 *)(d+4) = (x LS 8) | (w RS 24);
+			x = *(u32 *)(s+11);
+			*(u32 *)(d+8) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+15);
+			*(u32 *)(d+12) = (x LS 8) | (w RS 24);
+		}
+		break;
+	}
+	if (n&16) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&8) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&4) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&2) {
+		*d++ = *s++; *d++ = *s++;
+	}
+	if (n&1) {
+		*d = *s;
+	}
+	return dest;
+#endif
+
+	for (; n; n--) *d++ = *s++;
+	return dest;
+}
+
 // users can define a new stack size if needed
 #ifndef SMT_STACK_SIZE
 #define SMT_STACK_SIZE 257
@@ -14,8 +225,6 @@
 
 #define SMT_KEY_BYTES 32
 #define SMT_VALUE_BYTES 32
-
-const uint8_t SMT_ZERO[SMT_VALUE_BYTES] = {0};
 
 enum SMTErrorCode {
   // SMT
@@ -49,8 +258,8 @@ int smt_state_insert(smt_state_t *state, const uint8_t *key,
                      const uint8_t *value) {
   if (state->len < state->capacity) {
     /* shortcut, append at end */
-    memcpy(state->pairs[state->len].key, key, SMT_KEY_BYTES);
-    memcpy(state->pairs[state->len].value, value, SMT_KEY_BYTES);
+    _smt_fast_memcpy(state->pairs[state->len].key, key, SMT_KEY_BYTES);
+    _smt_fast_memcpy(state->pairs[state->len].value, value, SMT_KEY_BYTES);
     state->len++;
     return 0;
   }
@@ -67,7 +276,7 @@ int smt_state_insert(smt_state_t *state, const uint8_t *key,
     return ERROR_INSUFFICIENT_CAPACITY;
   }
 
-  memcpy(state->pairs[i].value, value, SMT_VALUE_BYTES);
+  _smt_fast_memcpy(state->pairs[i].value, value, SMT_VALUE_BYTES);
   return 0;
 }
 
@@ -75,7 +284,7 @@ int smt_state_fetch(smt_state_t *state, const uint8_t *key, uint8_t *value) {
   int32_t i = state->len - 1;
   for (; i >= 0; i--) {
     if (memcmp(key, state->pairs[i].key, SMT_KEY_BYTES) == 0) {
-      memcpy(value, state->pairs[i].value, SMT_VALUE_BYTES);
+      _smt_fast_memcpy(value, state->pairs[i].value, SMT_VALUE_BYTES);
       return 0;
     }
   }
@@ -110,9 +319,9 @@ void smt_state_normalize(smt_state_t *state) {
       next++;
     }
     if (item_index != sorted) {
-      memcpy(state->pairs[sorted].key, state->pairs[item_index].key,
+      _smt_fast_memcpy(state->pairs[sorted].key, state->pairs[item_index].key,
              SMT_KEY_BYTES);
-      memcpy(state->pairs[sorted].value, state->pairs[item_index].value,
+      _smt_fast_memcpy(state->pairs[sorted].value, state->pairs[item_index].value,
              SMT_VALUE_BYTES);
     }
     sorted++;
@@ -142,9 +351,7 @@ void _smt_clear_bit(uint8_t *data, int offset) {
 
 void _smt_copy_bits(uint8_t *source, int first_kept_bit) {
   int first_byte = first_kept_bit / 8;
-  for (int i = 0; i < first_byte; i++) {
-    source[i] = 0;
-  }
+  _smt_fast_memset(source, 0, first_byte);
   for (int i = first_byte * 8; i < first_kept_bit; i++) {
     _smt_clear_bit(source, i);
   }
@@ -152,38 +359,137 @@ void _smt_copy_bits(uint8_t *source, int first_kept_bit) {
 
 void _smt_parent_path(uint8_t *key, uint8_t height) {
   if (height == 255) {
-    memset(key, 0, 32);
+    _smt_fast_memset(key, 0, 32);
   } else {
     _smt_copy_bits(key, height + 1);
   }
 }
 
 int _smt_zero_value(const uint8_t *value) {
-  for (int i = 0; i < 32; i++) {
-    if (value[i] != 0) {
+  // TODO: is alignment something we should take care of?
+  const uint64_t *p = (const uint64_t *) value;
+  for (int i = 0; i < 4; i++) {
+    if (p[i] != 0) {
       return 0;
     }
   }
   return 1;
 }
 
-/* Notice that output might collide with one of lhs, or rhs */
-void _smt_merge(uint8_t height, const uint8_t *node_key, const uint8_t *lhs,
-                const uint8_t *rhs, uint8_t *output) {
-  if (_smt_zero_value(lhs) && _smt_zero_value(rhs)) {
-    memcpy(output, SMT_ZERO, SMT_VALUE_BYTES);
-  } else {
+#define _SMT_MERGE_VALUE_VALUE 0
+#define _SMT_MERGE_VALUE_MERGE_WITH_ZERO 1
+
+typedef struct {
+  uint8_t t;
+
+  uint8_t value[SMT_VALUE_BYTES];
+  uint8_t base_key[SMT_KEY_BYTES];
+  uint8_t zero_bits[SMT_KEY_BYTES];
+  uint8_t base_height;
+  uint8_t zero_count;
+} _smt_merge_value_t;
+
+void _smt_merge_value_from_h256(const uint8_t *v, _smt_merge_value_t *out) {
+  out->t = _SMT_MERGE_VALUE_VALUE;
+  _smt_fast_memcpy(out->value, v, SMT_VALUE_BYTES);
+}
+
+void _smt_merge_value_zero(_smt_merge_value_t *out) {
+  out->t = _SMT_MERGE_VALUE_VALUE;
+  _smt_fast_memset(out->value, 0, SMT_VALUE_BYTES);
+}
+
+int _smt_merge_value_is_zero(const _smt_merge_value_t *v) {
+  return (v->t == _SMT_MERGE_VALUE_VALUE) && _smt_zero_value(v->value);
+}
+
+const uint8_t _SMT_MERGE_NORMAL = 1;
+const uint8_t _SMT_MERGE_ZEROS = 2;
+
+void _smt_merge_value_hash(const _smt_merge_value_t *v, uint8_t *out) {
+  if (v->t == _SMT_MERGE_VALUE_MERGE_WITH_ZERO) {
     blake2b_state blake2b_ctx;
-    blake2b_init(&blake2b_ctx, 32);
+    blake2b_init(&blake2b_ctx, SMT_VALUE_BYTES);
 
-    blake2b_update(&blake2b_ctx, &height, 1);
-    blake2b_update(&blake2b_ctx, node_key, 32);
-    blake2b_update(&blake2b_ctx, lhs, 32);
-    blake2b_update(&blake2b_ctx, rhs, 32);
-
-    blake2b_final(&blake2b_ctx, output, 32);
+    blake2b_update(&blake2b_ctx, &_SMT_MERGE_ZEROS, 1);
+    blake2b_update(&blake2b_ctx, &(v->base_height), 1);
+    blake2b_update(&blake2b_ctx, v->base_key, SMT_KEY_BYTES);
+    blake2b_update(&blake2b_ctx, v->value, SMT_VALUE_BYTES);
+    blake2b_update(&blake2b_ctx, v->zero_bits, SMT_KEY_BYTES);
+    blake2b_update(&blake2b_ctx, &(v->zero_count), 1);
+    blake2b_final(&blake2b_ctx, out, SMT_VALUE_BYTES);
+  } else {
+    _smt_fast_memcpy(out, v->value, SMT_VALUE_BYTES);
   }
 }
+
+void _smt_merge_with_zero(uint8_t height, const uint8_t *node_key,
+                          const _smt_merge_value_t *v, int set_bit,
+                          _smt_merge_value_t *out) {
+  if (v->t == _SMT_MERGE_VALUE_MERGE_WITH_ZERO) {
+    if (out != v) {
+      _smt_fast_memcpy(out, v, sizeof(_smt_merge_value_t));
+    }
+    if (set_bit) {
+      _smt_set_bit(out->zero_bits, height);
+    }
+    out->zero_count++;
+  } else {
+    out->t = _SMT_MERGE_VALUE_MERGE_WITH_ZERO;
+    out->base_height = height;
+    _smt_fast_memcpy(out->base_key, node_key, SMT_KEY_BYTES);
+    if (out != v) {
+      _smt_fast_memcpy(out->value, v->value, SMT_VALUE_BYTES);
+    }
+    _smt_fast_memset(out->zero_bits, 0, 32);
+    if (set_bit) {
+      _smt_set_bit(out->zero_bits, height);
+    }
+    out->zero_count = 1;
+  }
+}
+
+/* Notice that output might collide with one of lhs, or rhs */
+void _smt_merge(uint8_t height, const uint8_t *node_key,
+                const _smt_merge_value_t *lhs,
+                const _smt_merge_value_t *rhs,
+                _smt_merge_value_t *out) {
+  int lhs_zero = _smt_merge_value_is_zero(lhs);
+  int rhs_zero = _smt_merge_value_is_zero(rhs);
+
+  if (lhs_zero && rhs_zero) {
+    _smt_merge_value_zero(out);
+    return;
+  }
+  if (lhs_zero) {
+    _smt_merge_with_zero(height, node_key, rhs, 1, out);
+    return;
+  }
+  if (rhs_zero) {
+    _smt_merge_with_zero(height, node_key, lhs, 0, out);
+    return;
+  }
+
+  blake2b_state blake2b_ctx;
+  blake2b_init(&blake2b_ctx, SMT_VALUE_BYTES);
+  uint8_t data[SMT_VALUE_BYTES];
+
+  blake2b_update(&blake2b_ctx, &_SMT_MERGE_NORMAL, 1);
+  blake2b_update(&blake2b_ctx, &height, 1);
+  blake2b_update(&blake2b_ctx, node_key, SMT_KEY_BYTES);
+  _smt_merge_value_hash(lhs, data);
+  blake2b_update(&blake2b_ctx, data, SMT_VALUE_BYTES);
+  _smt_merge_value_hash(rhs, data);
+  blake2b_update(&blake2b_ctx, data, SMT_VALUE_BYTES);
+
+  blake2b_final(&blake2b_ctx, data, SMT_VALUE_BYTES);
+  _smt_merge_value_from_h256(data, out);
+}
+
+const _smt_merge_value_t SMT_ZERO = {
+  .t = _SMT_MERGE_VALUE_VALUE,
+  .value = {0}
+};
 
 /*
  * Theoretically, a stack size of x should be able to process as many as
@@ -193,7 +499,7 @@ void _smt_merge(uint8_t height, const uint8_t *node_key, const uint8_t *lhs,
 int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
                        const uint8_t *proof, uint32_t proof_length) {
   uint8_t stack_keys[SMT_STACK_SIZE][SMT_KEY_BYTES];
-  uint8_t stack_values[SMT_STACK_SIZE][SMT_VALUE_BYTES];
+  _smt_merge_value_t stack_values[SMT_STACK_SIZE];
   uint16_t stack_heights[SMT_STACK_SIZE] = {0};
 
   uint32_t proof_index = 0;
@@ -209,10 +515,9 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
         if (leave_index >= pairs->len) {
           return ERROR_INVALID_PROOF;
         }
-        memcpy(stack_keys[stack_top], pairs->pairs[leave_index].key,
+        _smt_fast_memcpy(stack_keys[stack_top], pairs->pairs[leave_index].key,
                SMT_KEY_BYTES);
-        memcpy(stack_values[stack_top], pairs->pairs[leave_index].value,
-               SMT_VALUE_BYTES);
+        _smt_merge_value_from_h256(pairs->pairs[leave_index].value, &stack_values[stack_top]);
         stack_heights[stack_top] = 0;
         stack_top++;
         leave_index++;
@@ -224,24 +529,62 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
         if (proof_index + 32 > proof_length) {
           return ERROR_INVALID_PROOF;
         }
-        const uint8_t *sibling_node = &proof[proof_index];
+        _smt_merge_value_t sibling_node;
+        _smt_merge_value_from_h256(&proof[proof_index], &sibling_node);
         proof_index += 32;
         uint8_t *key = stack_keys[stack_top - 1];
-        uint8_t *value = stack_values[stack_top - 1];
+        _smt_merge_value_t *value = &stack_values[stack_top - 1];
         uint16_t height = stack_heights[stack_top - 1];
         uint16_t *height_ptr = &stack_heights[stack_top - 1];
         if (height > 255) {
           return ERROR_INVALID_PROOF;
         }
         uint8_t parent_key[SMT_KEY_BYTES];
-        memcpy(parent_key, key, SMT_KEY_BYTES);
+        _smt_fast_memcpy(parent_key, key, SMT_KEY_BYTES);
         _smt_parent_path(parent_key, height);
 
         // push value
         if (_smt_get_bit(key, height)) {
-          _smt_merge((uint8_t)height, parent_key, sibling_node, value, value);
+          _smt_merge((uint8_t)height, parent_key, &sibling_node, value, value);
         } else {
-          _smt_merge((uint8_t)height, parent_key, value, sibling_node, value);
+          _smt_merge((uint8_t)height, parent_key, value, &sibling_node, value);
+        }
+        // push key
+        _smt_parent_path(key, height);
+        // push height
+        *height_ptr = height + 1;
+      } break;
+      case 0x51: {
+        if (stack_top == 0) {
+          return ERROR_INVALID_STACK;
+        }
+        if (proof_index + 98 > proof_length) {
+          return ERROR_INVALID_PROOF;
+        }
+        _smt_merge_value_t sibling_node;
+        sibling_node.t = _SMT_MERGE_VALUE_MERGE_WITH_ZERO;
+        sibling_node.base_height = proof[proof_index];
+        sibling_node.zero_count = proof[proof_index + 1];
+        _smt_fast_memcpy(&sibling_node.base_key, &proof[proof_index + 2], 32);
+        _smt_fast_memcpy(&sibling_node.value, &proof[proof_index + 34], 32);
+        _smt_fast_memcpy(&sibling_node.zero_bits, &proof[proof_index + 66], 32);
+        proof_index += 98;
+        uint8_t *key = stack_keys[stack_top - 1];
+        _smt_merge_value_t *value = &stack_values[stack_top - 1];
+        uint16_t height = stack_heights[stack_top - 1];
+        uint16_t *height_ptr = &stack_heights[stack_top - 1];
+        if (height > 255) {
+          return ERROR_INVALID_PROOF;
+        }
+        uint8_t parent_key[SMT_KEY_BYTES];
+        _smt_fast_memcpy(parent_key, key, SMT_KEY_BYTES);
+        _smt_parent_path(parent_key, height);
+
+        // push value
+        if (_smt_get_bit(key, height)) {
+          _smt_merge((uint8_t)height, parent_key, &sibling_node, value, value);
+        } else {
+          _smt_merge((uint8_t)height, parent_key, value, &sibling_node, value);
         }
         // push key
         _smt_parent_path(key, height);
@@ -256,11 +599,11 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
 
         uint16_t height_a = stack_heights[stack_top - 2];
         uint8_t *key_a = stack_keys[stack_top - 2];
-        uint8_t *value_a = stack_values[stack_top - 2];
+        _smt_merge_value_t *value_a = &stack_values[stack_top - 2];
 
         uint16_t height_b = stack_heights[stack_top - 1];
         uint8_t *key_b = stack_keys[stack_top - 1];
-        uint8_t *value_b = stack_values[stack_top - 1];
+        _smt_merge_value_t *value_b = &stack_values[stack_top - 1];
         stack_top -= 2;
         if (height_a != height_b) {
           return ERROR_INVALID_PROOF;
@@ -269,7 +612,7 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
           return ERROR_INVALID_PROOF;
         }
         uint8_t parent_key[SMT_KEY_BYTES];
-        memcpy(parent_key, key_a, SMT_KEY_BYTES);
+        _smt_fast_memcpy(parent_key, key_a, SMT_KEY_BYTES);
         _smt_parent_path(parent_key, (uint8_t)height_a);
 
         // 2 keys should have same parent keys
@@ -284,7 +627,7 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
           _smt_merge(height_a, parent_key, value_a, value_b, value_a);
         }
         // push key
-        memcpy(key_a, parent_key, SMT_KEY_BYTES);
+        _smt_fast_memcpy(key_a, parent_key, SMT_KEY_BYTES);
         // push height
         *height_a_ptr = height_a + 1;
         stack_top++;
@@ -307,12 +650,12 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
         uint16_t *base_height_ptr = &stack_heights[stack_top - 1];
         uint16_t base_height = stack_heights[stack_top - 1];
         uint8_t *key = stack_keys[stack_top - 1];
-        uint8_t *value = stack_values[stack_top - 1];
+        _smt_merge_value_t *value = &stack_values[stack_top - 1];
         if (base_height > 255) {
           return ERROR_INVALID_PROOF;
         }
         uint8_t parent_key[SMT_KEY_BYTES];
-        memcpy(parent_key, key, SMT_KEY_BYTES);
+        _smt_fast_memcpy(parent_key, key, SMT_KEY_BYTES);
         uint16_t height_u16 = base_height;
         for (uint16_t idx = 0; idx < zero_count; idx++) {
           height_u16 = base_height + idx;
@@ -320,20 +663,20 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
             return ERROR_INVALID_PROOF;
           }
           // the following code can be omitted:
-          // memcpy(parent_key, key, SMT_KEY_BYTES);
+          // _smt_fast_memcpy(parent_key, key, SMT_KEY_BYTES);
           // A key's parent's parent can be calculated from parent.
           // it's not needed to do it from scratch.
           // Make sure height_u16 is in increase order
           _smt_parent_path(parent_key, (uint8_t)height_u16);
           // push value
           if (_smt_get_bit(key, (uint8_t)height_u16)) {
-            _smt_merge((uint8_t)height_u16, parent_key, SMT_ZERO, value, value);
+            _smt_merge((uint8_t)height_u16, parent_key, &SMT_ZERO, value, value);
           } else {
-            _smt_merge((uint8_t)height_u16, parent_key, value, SMT_ZERO, value);
+            _smt_merge((uint8_t)height_u16, parent_key, value, &SMT_ZERO, value);
           }
         }
         // push key
-        memcpy(key, parent_key, SMT_KEY_BYTES);
+        _smt_fast_memcpy(key, parent_key, SMT_KEY_BYTES);
         // push height
         *base_height_ptr = height_u16 + 1;
       } break;
@@ -352,7 +695,7 @@ int smt_calculate_root(uint8_t *buffer, const smt_state_t *pairs,
     return ERROR_INVALID_PROOF;
   }
 
-  memcpy(buffer, stack_values[0], 32);
+  _smt_merge_value_hash(&stack_values[0], buffer);
   return 0;
 }
 

--- a/c/rust-tests/build.rs
+++ b/c/rust-tests/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rerun-if-changed=../ckb_smt.h");
+
     cc::Build::new()
         .file("src/tests/ckb_smt.c")
         .static_flag(true)

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,17 +1,125 @@
 use crate::h256::H256;
 use crate::traits::Hasher;
 
+const MERGE_NORMAL: u8 = 1;
+const MERGE_ZEROS: u8 = 2;
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum MergeValue {
+    Value(H256),
+    MergeWithZero {
+        base_height: u8,
+        base_key: H256,
+        base_value: H256,
+        zero_bits: H256,
+        zero_count: u8,
+    },
+}
+
+impl MergeValue {
+    pub fn from_h256(v: H256) -> Self {
+        MergeValue::Value(v)
+    }
+
+    pub fn zero() -> Self {
+        MergeValue::Value(H256::zero())
+    }
+
+    pub fn is_zero(&self) -> bool {
+        if let MergeValue::Value(v) = self {
+            return v.is_zero();
+        }
+        false
+    }
+
+    pub fn hash<H: Hasher + Default>(&self) -> H256 {
+        match self {
+            MergeValue::Value(v) => *v,
+            MergeValue::MergeWithZero {
+                base_height,
+                base_key,
+                base_value,
+                zero_bits,
+                zero_count,
+            } => {
+                let mut hasher = H::default();
+                hasher.write_byte(MERGE_ZEROS);
+                hasher.write_byte(*base_height);
+                hasher.write_h256(base_key);
+                hasher.write_h256(base_value);
+                hasher.write_h256(zero_bits);
+                hasher.write_byte(*zero_count);
+                hasher.finish()
+            }
+        }
+    }
+}
+
 /// Merge two hash with node information
 /// this function optimized for ZERO_HASH
 /// if lhs and rhs both are ZERO_HASH return ZERO_HASH, otherwise hash all info.
-pub fn merge<H: Hasher + Default>(height: u8, node_key: &H256, lhs: &H256, rhs: &H256) -> H256 {
+pub fn merge<H: Hasher + Default>(
+    height: u8,
+    node_key: &H256,
+    lhs: &MergeValue,
+    rhs: &MergeValue,
+) -> MergeValue {
     if lhs.is_zero() && rhs.is_zero() {
-        return H256::zero();
+        return MergeValue::zero();
+    }
+    if lhs.is_zero() {
+        return merge_with_zero::<H>(height, node_key, rhs, true);
+    }
+    if rhs.is_zero() {
+        return merge_with_zero::<H>(height, node_key, lhs, false);
     }
     let mut hasher = H::default();
+    hasher.write_byte(MERGE_NORMAL);
     hasher.write_byte(height);
     hasher.write_h256(node_key);
-    hasher.write_h256(lhs);
-    hasher.write_h256(rhs);
-    hasher.finish()
+    hasher.write_h256(&lhs.hash::<H>());
+    hasher.write_h256(&rhs.hash::<H>());
+    MergeValue::Value(hasher.finish())
+}
+
+fn merge_with_zero<H: Hasher + Default>(
+    height: u8,
+    node_key: &H256,
+    value: &MergeValue,
+    set_bit: bool,
+) -> MergeValue {
+    match value {
+        MergeValue::Value(v) => {
+            let mut zero_bits = H256::zero();
+            if set_bit {
+                zero_bits.set_bit(height);
+            }
+            MergeValue::MergeWithZero {
+                base_height: height,
+                base_key: *node_key,
+                base_value: *v,
+                zero_bits,
+                zero_count: 1,
+            }
+        }
+        MergeValue::MergeWithZero {
+            base_height,
+            base_key,
+            base_value,
+            zero_bits,
+            zero_count,
+        } => {
+            let mut zero_bits = *zero_bits;
+            if set_bit {
+                zero_bits.set_bit(height);
+            }
+            MergeValue::MergeWithZero {
+                base_height: *base_height,
+                base_key: *base_key,
+                base_value: *base_value,
+                zero_bits,
+                zero_count: zero_count.wrapping_add(1),
+            }
+        }
+    }
 }

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use crate::{
-    blake2b::Blake2bHasher, default_store::DefaultStore, error::Error, MerkleProof,
-    SparseMerkleTree,
+    blake2b::Blake2bHasher, default_store::DefaultStore, error::Error, merge::MergeValue,
+    MerkleProof, SparseMerkleTree,
 };
 use proptest::prelude::*;
 use rand::prelude::{Rng, SliceRandom};
@@ -93,8 +93,8 @@ fn test_merkle_root() {
     }
 
     let expected_root: H256 = [
-        25, 31, 27, 18, 99, 195, 111, 162, 55, 149, 47, 19, 211, 144, 13, 233, 103, 239, 1, 29, 67,
-        215, 199, 86, 55, 113, 197, 142, 140, 208, 87, 17,
+        127, 59, 141, 136, 236, 65, 63, 195, 247, 128, 87, 249, 79, 167, 42, 93, 245, 168, 199,
+        243, 180, 214, 34, 85, 132, 149, 56, 235, 179, 253, 196, 115,
     ]
     .into();
     assert_eq!(tree.store().leaves_map().len(), 9);
@@ -324,9 +324,15 @@ fn leaves_bitmap(max_leaves_bitmap: usize) -> impl Strategy<Value = Vec<H256>> {
     )
 }
 
-fn merkle_proof(max_proof: usize) -> impl Strategy<Value = Vec<H256>> {
-    prop::collection::vec(prop::array::uniform32(0u8..), max_proof)
-        .prop_flat_map(|proof| Just(proof.into_iter().map(|item| item.into()).collect()))
+fn merkle_proof(max_proof: usize) -> impl Strategy<Value = Vec<MergeValue>> {
+    prop::collection::vec(prop::array::uniform32(0u8..), max_proof).prop_flat_map(|proof| {
+        Just(
+            proof
+                .into_iter()
+                .map(|item| MergeValue::from_h256(item.into()))
+                .collect(),
+        )
+    })
 }
 
 proptest! {


### PR DESCRIPTION
This change reduces the number of zero-related hashes
performed. Multiple consecutive hashes against zero will be reduced to
one. The verification cost is thus significantly reduced, initial
benchmark shows that verifying a single key in SMT, consumes roughly
130k cycles using current CKB's cost model.