### PR TITLE
fix invalid conversion error from 'void*' to 'unsigned char*'

### DIFF
--- a/c/ckb_smt.h
+++ b/c/ckb_smt.h
@@ -11,7 +11,7 @@
 // the awesome musl libc project: https://www.musl-libc.org/
 void *_smt_fast_memset(void *dest, int c, size_t n)
 {
-	unsigned char *s = dest;
+	unsigned char *s = (unsigned char *)dest;
 	size_t k;
 
 	/* Fill head and tail with minimal branching. Each
@@ -99,8 +99,8 @@ void *_smt_fast_memset(void *dest, int c, size_t n)
 
 void *_smt_fast_memcpy(void *restrict dest, const void *restrict src, size_t n)
 {
-	unsigned char *d = dest;
-	const unsigned char *s = src;
+	unsigned char *d = (unsigned char *)dest;
+	const unsigned char *s = (unsigned char *)src;
 
 #ifdef __GNUC__
 


### PR DESCRIPTION
## G++ compilation error in Polyjuice:

```
deps/godwoken-scripts/c/deps/sparse-merkle-tree/c/ckb_smt.h: In function 'void* _smt_fast_memset(void*, int, size_t)':
deps/godwoken-scripts/c/deps/sparse-merkle-tree/c/ckb_smt.h:14:21: error: invalid conversion from 'void*' to 'unsigned char*' [-fpermissive]
  unsigned char *s = dest;
                     ^~~~
deps/godwoken-scripts/c/deps/sparse-merkle-tree/c/ckb_smt.h: In function 'void* _smt_fast_memcpy(void*, const void*, size_t)':
deps/godwoken-scripts/c/deps/sparse-merkle-tree/c/ckb_smt.h:102:21: error: invalid conversion from 'void* __restrict__' to 'unsigned char*' [-fpermissive]
  unsigned char *d = dest;
                     ^~~~
deps/godwoken-scripts/c/deps/sparse-merkle-tree/c/ckb_smt.h:103:27: error: invalid conversion from 'const void* __restrict__' to 'const unsigned char*' [-fpermissive]
  const unsigned char *s = src;
                           ^~~
Makefile:82: recipe for target 'build/test_contracts' failed
make: *** [build/test_contracts] Error 1
make: *** [Makefile:47: all-via-docker] Error 2
```