### PR TITLE
Replace H256 with the one in rust-numext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ blake2b = ["blake2b-rs"]
 [dependencies]
 cfg-if = "0.1"
 blake2b-rs = { version = "0.1", optional = true }
+numext-fixed-hash = "0.1.6"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/src/h256.rs
+++ b/src/h256.rs
@@ -1,41 +1,37 @@
+use numext_fixed_hash;
+
 use core::cmp::Ordering;
 
 /// Represent 256 bits
-#[derive(Eq, PartialEq, Debug, Default, Hash, Clone, Copy)]
-pub struct H256([u8; 32]);
+#[derive(Eq, PartialEq, Debug, Default, Hash, Clone)]
+pub struct H256 {
+    inner: numext_fixed_hash::H256,
+}
 
-const ZERO: H256 = H256([0u8; 32]);
 const BYTE_SIZE: u8 = 8;
 
 impl H256 {
-    pub const fn zero() -> Self {
-        ZERO
+    pub const fn empty() -> Self {
+        H256 { inner: numext_fixed_hash::H256::empty() }
     }
 
     pub fn is_zero(&self) -> bool {
-        self == &ZERO
+        self.inner.is_empty()
     }
 
     #[inline]
     pub fn get_bit(&self, i: u8) -> bool {
-        let byte_pos = i / BYTE_SIZE;
-        let bit_pos = i % BYTE_SIZE;
-        let bit = self.0[byte_pos as usize] >> bit_pos & 1;
-        bit != 0
+        self.inner.bit(i.into()).unwrap_or(false)
     }
 
     #[inline]
     pub fn set_bit(&mut self, i: u8) {
-        let byte_pos = i / BYTE_SIZE;
-        let bit_pos = i % BYTE_SIZE;
-        self.0[byte_pos as usize] |= 1 << bit_pos as u8;
+        self.inner.set_bit(i.into(), true);
     }
 
     #[inline]
     pub fn clear_bit(&mut self, i: u8) {
-        let byte_pos = i / BYTE_SIZE;
-        let bit_pos = i % BYTE_SIZE;
-        self.0[byte_pos as usize] &= !((1 << bit_pos) as u8);
+        self.inner.set_bit(i.into(), false);
     }
 
     #[inline]
@@ -44,7 +40,7 @@ impl H256 {
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        &self.0[..]
+        self.inner.as_bytes()
     }
 
     /// Treat H256 as a path in a tree
@@ -62,7 +58,7 @@ impl H256 {
     /// return parent_path of self
     pub fn parent_path(&self, height: u8) -> Self {
         if height == core::u8::MAX {
-            H256::zero()
+            H256::empty()
         } else {
             self.copy_bits(height + 1)
         }
@@ -70,16 +66,17 @@ impl H256 {
 
     /// Copy bits and return a new H256
     pub fn copy_bits(&self, start: u8) -> Self {
-        let mut target = H256::zero();
+        // It can also be implemented with And, but the performance is not as good as this 
+        let mut target = H256::empty();
 
         let start_byte = (start / BYTE_SIZE) as usize;
         // copy bytes
-        target.0[start_byte..].copy_from_slice(&self.0[start_byte..]);
+        target.inner.0[start_byte..].copy_from_slice(&self.inner.0[start_byte..]);
 
         // reset remain bytes
         let remain = start % BYTE_SIZE;
         if remain > 0 {
-            target.0[start_byte] &= 0b11111111 << remain
+            target.inner.0[start_byte] &= 0b11111111 << remain
         }
 
         target
@@ -95,18 +92,20 @@ impl PartialOrd for H256 {
 impl Ord for H256 {
     fn cmp(&self, other: &Self) -> Ordering {
         // Compare bits from heigher to lower (255..0)
-        self.0.iter().rev().cmp(other.0.iter().rev())
+        self.inner.0.iter().rev().cmp(other.inner.0.iter().rev())
     }
 }
 
 impl From<[u8; 32]> for H256 {
     fn from(v: [u8; 32]) -> H256 {
-        H256(v)
+        H256{
+            inner: numext_fixed_hash::H256::from(v),
+        }
     }
 }
 
 impl Into<[u8; 32]> for H256 {
     fn into(self: H256) -> [u8; 32] {
-        self.0
+        self.inner.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! impl Value for Word {
 //!    fn to_h256(&self) -> H256 {
 //!        if self.0.is_empty() {
-//!            return H256::zero();
+//!            return H256::empty();
 //!        }
 //!        let mut buf = [0u8; 32];
 //!        let mut hasher = new_blake2b();

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -20,7 +20,7 @@ impl MergeValue {
     }
 
     pub fn zero() -> Self {
-        MergeValue::Value(H256::zero())
+        MergeValue::Value(H256::empty())
     }
 
     pub fn is_zero(&self) -> bool {
@@ -32,7 +32,7 @@ impl MergeValue {
 
     pub fn hash<H: Hasher + Default>(&self) -> H256 {
         match self {
-            MergeValue::Value(v) => *v,
+            MergeValue::Value(v) => v.clone(),
             MergeValue::MergeWithZero {
                 base_node,
                 zero_bits,
@@ -97,7 +97,7 @@ fn merge_with_zero<H: Hasher + Default>(
 ) -> MergeValue {
     match value {
         MergeValue::Value(v) => {
-            let mut zero_bits = H256::zero();
+            let mut zero_bits = H256::empty();
             if set_bit {
                 zero_bits.set_bit(height);
             }
@@ -113,12 +113,12 @@ fn merge_with_zero<H: Hasher + Default>(
             zero_bits,
             zero_count,
         } => {
-            let mut zero_bits = *zero_bits;
+            let mut zero_bits = zero_bits.clone();
             if set_bit {
                 zero_bits.set_bit(height);
             }
             MergeValue::MergeWithZero {
-                base_node: *base_node,
+                base_node: base_node.clone(),
                 zero_bits,
                 zero_count: zero_count.wrapping_add(1),
             }

--- a/src/merkle_proof.rs
+++ b/src/merkle_proof.rs
@@ -59,7 +59,7 @@ impl MerkleProof {
             });
         }
         // sort leaves
-        leaves.sort_unstable_by_key(|(k, _v)| *k);
+        leaves.sort_unstable_by_key(|(k, _v)| k.clone());
 
         let (leaves_bitmap, merkle_path) = self.take();
 
@@ -69,7 +69,7 @@ impl MerkleProof {
         let mut leaf_index = 0;
         let mut merkle_path_index = 0;
         while leaf_index < leaves.len() {
-            let (leaf_key, _value) = leaves[leaf_index];
+            let (leaf_key, _value) = leaves[leaf_index].clone();
             let fork_height = if leaf_index + 1 < leaves.len() {
                 leaf_key.fork_height(&leaves[leaf_index + 1].0)
             } else {
@@ -184,7 +184,7 @@ pub struct CompiledMerkleProof(pub Vec<u8>);
 
 impl CompiledMerkleProof {
     pub fn compute_root<H: Hasher + Default>(&self, mut leaves: Vec<(H256, H256)>) -> Result<H256> {
-        leaves.sort_unstable_by_key(|(k, _v)| *k);
+        leaves.sort_unstable_by_key(|(k, _v)| k.clone());
         let mut program_index = 0;
         let mut leaf_index = 0;
         let mut stack: Vec<(u16, H256, MergeValue)> = Vec::new();
@@ -197,7 +197,7 @@ impl CompiledMerkleProof {
                     if leaf_index >= leaves.len() {
                         return Err(Error::CorruptedStack);
                     }
-                    let (k, v) = leaves[leaf_index];
+                    let (k, v) = leaves[leaf_index].clone();
                     stack.push((0, k, MergeValue::from_h256(v)));
                     leaf_index += 1;
                 }
@@ -308,7 +308,7 @@ impl CompiledMerkleProof {
                     if base_height > 255 {
                         return Err(Error::CorruptedProof);
                     }
-                    let mut parent_key = key;
+                    let mut parent_key = key.clone();
                     let mut height_u16 = base_height;
                     for idx in 0..zero_count {
                         if base_height + idx > 255 {

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -13,33 +13,33 @@ fn test_default_root() {
     let mut tree = SMT::default();
     assert_eq!(tree.store().branches_map().len(), 0);
     assert_eq!(tree.store().leaves_map().len(), 0);
-    assert_eq!(tree.root(), &H256::zero());
+    assert_eq!(tree.root(), &H256::empty());
 
     // insert a key-value
-    tree.update(H256::zero(), [42u8; 32].into())
+    tree.update(H256::empty(), [42u8; 32].into())
         .expect("update");
-    assert_ne!(tree.root(), &H256::zero());
+    assert_ne!(tree.root(), &H256::empty());
     assert_ne!(tree.store().branches_map().len(), 0);
     assert_ne!(tree.store().leaves_map().len(), 0);
-    assert_eq!(tree.get(&H256::zero()).expect("get"), [42u8; 32].into());
+    assert_eq!(tree.get(&H256::empty()).expect("get"), [42u8; 32].into());
     // update zero is to delete the key
-    tree.update(H256::zero(), H256::zero()).expect("update");
-    assert_eq!(tree.root(), &H256::zero());
-    assert_eq!(tree.get(&H256::zero()).expect("get"), H256::zero());
+    tree.update(H256::empty(), H256::empty()).expect("update");
+    assert_eq!(tree.root(), &H256::empty());
+    assert_eq!(tree.get(&H256::empty()).expect("get"), H256::empty());
 }
 
 #[test]
 fn test_default_tree() {
     let tree = SMT::default();
-    assert_eq!(tree.get(&H256::zero()).expect("get"), H256::zero());
-    let proof = tree.merkle_proof(vec![H256::zero()]).expect("merkle proof");
+    assert_eq!(tree.get(&H256::empty()).expect("get"), H256::empty());
+    let proof = tree.merkle_proof(vec![H256::empty()]).expect("merkle proof");
     let root = proof
-        .compute_root::<Blake2bHasher>(vec![(H256::zero(), H256::zero())])
+        .compute_root::<Blake2bHasher>(vec![(H256::empty(), H256::empty())])
         .expect("root");
     assert_eq!(&root, tree.root());
-    let proof = tree.merkle_proof(vec![H256::zero()]).expect("merkle proof");
+    let proof = tree.merkle_proof(vec![H256::empty()]).expect("merkle proof");
     let root2 = proof
-        .compute_root::<Blake2bHasher>(vec![(H256::zero(), [42u8; 32].into())])
+        .compute_root::<Blake2bHasher>(vec![(H256::empty(), [42u8; 32].into())])
         .expect("root");
     assert_ne!(&root2, tree.root());
 }
@@ -61,7 +61,7 @@ fn test_default_merkle_proof() {
     // let root = proof
     //     .compute_root::<Blake2bHasher>(vec![([42u8; 32].into(), [42u8; 32].into())])
     //     .expect("compute root");
-    // assert_ne!(root, H256::zero());
+    // assert_ne!(root, H256::empty());
 }
 
 #[test]
@@ -109,9 +109,9 @@ fn test_zero_value_donot_change_root() {
         0, 1,
     ]
     .into();
-    let value = H256::zero();
+    let value = H256::empty();
     tree.update(key, value).unwrap();
-    assert_eq!(tree.root(), &H256::zero());
+    assert_eq!(tree.root(), &H256::empty());
     assert_eq!(tree.store().leaves_map().len(), 0);
     assert_eq!(tree.store().branches_map().len(), 0);
 }
@@ -130,8 +130,8 @@ fn test_zero_value_donot_change_store() {
     ]
     .into();
     tree.update(key, value).unwrap();
-    assert_ne!(tree.root(), &H256::zero());
-    let root = *tree.root();
+    assert_ne!(tree.root(), &H256::empty());
+    let root = tree.root().clone();
     let store = tree.store().clone();
 
     // insert a zero value leaf
@@ -165,12 +165,12 @@ fn test_delete_a_leaf() {
     ]
     .into();
     tree.update(key, value).unwrap();
-    assert_ne!(tree.root(), &H256::zero());
-    let root = *tree.root();
+    assert_ne!(tree.root(), &H256::empty());
+    let root = tree.root().clone();
     let store = tree.store().clone();
 
     // insert a leaf
-    let key = [
+    let key: H256 = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 1,
     ]
@@ -180,11 +180,11 @@ fn test_delete_a_leaf() {
         0, 1,
     ]
     .into();
-    tree.update(key, value).unwrap();
+    tree.update(key.clone(), value).unwrap();
     assert_ne!(tree.root(), &root);
 
     // delete a leaf
-    tree.update(key, H256::zero()).unwrap();
+    tree.update(key, H256::empty()).unwrap();
     assert_eq!(tree.root(), &root);
     assert_eq!(tree.store().leaves_map(), store.leaves_map());
     assert_eq!(tree.store().branches_map(), store.branches_map());
@@ -206,7 +206,7 @@ fn test_sibling_key_get() {
             0, 0, 0,
         ]);
         // get non exists sibling key should return zero value;
-        assert_eq!(H256::zero(), tree.get(&sibling_key).unwrap());
+        assert_eq!(H256::empty(), tree.get(&sibling_key).unwrap());
     }
 
     {
@@ -216,14 +216,14 @@ fn test_sibling_key_get() {
             0, 0, 0,
         ]);
         let value = H256::from([1u8; 32]);
-        tree.update(key, value).expect("update");
+        tree.update(key.clone(), value.clone()).expect("update");
 
         let sibling_key = H256::from([
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
         ]);
         let sibling_value = H256::from([2u8; 32]);
-        tree.update(sibling_key, sibling_value).expect("update");
+        tree.update(sibling_key.clone(), sibling_value.clone()).expect("update");
         // get sibling key should return corresponding value
         assert_eq!(value, tree.get(&key).unwrap());
         assert_eq!(sibling_value, tree.get(&sibling_key).unwrap());
@@ -234,7 +234,7 @@ fn test_construct(key: H256, value: H256) {
     // insert same value to sibling key will construct a different root
 
     let mut tree = SMT::default();
-    tree.update(key, value).expect("update");
+    tree.update(key.clone(), value.clone()).expect("update");
 
     let mut sibling_key = key;
     if sibling_key.get_bit(0) {
@@ -249,7 +249,7 @@ fn test_construct(key: H256, value: H256) {
 
 fn test_update(key: H256, value: H256) {
     let mut tree = SMT::default();
-    tree.update(key, value).expect("update");
+    tree.update(key.clone(), value.clone()).expect("update");
     assert_eq!(tree.get(&key), Ok(value));
 }
 
@@ -257,10 +257,10 @@ fn test_update_tree_store(key: H256, value: H256, value2: H256) {
     const EXPECTED_LEAVES_LEN: usize = 1;
 
     let mut tree = SMT::default();
-    tree.update(key, value).expect("update");
+    tree.update(key.clone(), value).expect("update");
     assert_eq!(tree.store().branches_map().len(), 256);
     assert_eq!(tree.store().leaves_map().len(), EXPECTED_LEAVES_LEN);
-    tree.update(key, value2).expect("update");
+    tree.update(key.clone(), value2.clone()).expect("update");
     assert_eq!(tree.store().branches_map().len(), 256);
     assert_eq!(tree.store().leaves_map().len(), EXPECTED_LEAVES_LEN);
     assert_eq!(tree.get(&key), Ok(value2));
@@ -270,16 +270,16 @@ fn test_merkle_proof(key: H256, value: H256) {
     const EXPECTED_MERKLE_PATH_SIZE: usize = 1;
 
     let mut tree = SMT::default();
-    tree.update(key, value).expect("update");
+    tree.update(key.clone(), value.clone()).expect("update");
     if !tree.is_empty() {
-        let proof = tree.merkle_proof(vec![key]).expect("proof");
+        let proof = tree.merkle_proof(vec![key.clone()]).expect("proof");
         let compiled_proof = proof
             .clone()
-            .compile(vec![(key, value)])
+            .compile(vec![(key.clone(), value.clone())])
             .expect("compile proof");
         assert!(proof.merkle_path().len() < EXPECTED_MERKLE_PATH_SIZE);
         assert!(proof
-            .verify::<Blake2bHasher>(tree.root(), vec![(key, value)])
+            .verify::<Blake2bHasher>(tree.root(), vec![(key.clone(), value.clone())])
             .expect("verify"));
         assert!(compiled_proof
             .verify::<Blake2bHasher>(tree.root(), vec![(key, value)])
@@ -341,7 +341,7 @@ proptest! {
         let mut list1: Vec<H256> = vec![key.into() , key2.into()];
         let mut list2 = list1.clone();
         // sort H256
-        list1.sort_unstable_by_key(|k| *k);
+        list1.sort_unstable_by_key(|k| k.clone());
         // sort by high bits to lower bits
         list2.sort_unstable_by(|k1, k2| {
             for i in (0u8..=255).rev() {
@@ -393,9 +393,9 @@ proptest! {
     fn test_smt_single_leaf_small((pairs, _n) in leaves(1, 50)){
         let smt = new_smt(pairs.clone());
         for (k, v) in pairs {
-            let proof = smt.merkle_proof(vec![k]).expect("gen proof");
-            let compiled_proof = proof.clone().compile(vec![(k, v)]).expect("compile proof");
-            assert!(proof.verify::<Blake2bHasher>(smt.root(), vec![(k, v)]).expect("verify proof"));
+            let proof = smt.merkle_proof(vec![k.clone()]).expect("gen proof");
+            let compiled_proof = proof.clone().compile(vec![(k.clone(), v.clone())]).expect("compile proof");
+            assert!(proof.verify::<Blake2bHasher>(smt.root(), vec![(k.clone(), v.clone())]).expect("verify proof"));
             assert!(compiled_proof.verify::<Blake2bHasher>(smt.root(), vec![(k, v)]).expect("verify compiled proof"));
         }
     }
@@ -404,9 +404,9 @@ proptest! {
     fn test_smt_single_leaf_large((pairs, _n) in leaves(50, 100)){
         let smt = new_smt(pairs.clone());
         for (k, v) in pairs {
-            let proof = smt.merkle_proof(vec![k]).expect("gen proof");
-            let compiled_proof = proof.clone().compile(vec![(k, v)]).expect("compile proof");
-            assert!(proof.verify::<Blake2bHasher>(smt.root(), vec![(k, v)]).expect("verify proof"));
+            let proof = smt.merkle_proof(vec![k.clone()]).expect("gen proof");
+            let compiled_proof = proof.clone().compile(vec![(k.clone(), v.clone())]).expect("compile proof");
+            assert!(proof.verify::<Blake2bHasher>(smt.root(), vec![(k.clone(), v.clone())]).expect("verify proof"));
             assert!(compiled_proof.verify::<Blake2bHasher>(smt.root(), vec![(k, v)]).expect("verify compiled proof"));
         }
     }
@@ -414,7 +414,7 @@ proptest! {
     #[test]
     fn test_smt_multi_leaves_small((pairs, n) in leaves(1, 50)){
         let smt = new_smt(pairs.clone());
-        let proof = smt.merkle_proof(pairs.iter().take(n).map(|(k, _v)| *k).collect()).expect("gen proof");
+        let proof = smt.merkle_proof(pairs.iter().take(n).map(|(k, _v)| k.clone()).collect()).expect("gen proof");
         let data: Vec<(H256, H256)> = pairs.into_iter().take(n).collect();
         let compiled_proof = proof.clone().compile(data.clone()).expect("compile proof");
         assert!(proof.verify::<Blake2bHasher>(smt.root(), data.clone()).expect("verify proof"));
@@ -425,7 +425,7 @@ proptest! {
     fn test_smt_multi_leaves_large((pairs, _n) in leaves(50, 100)){
         let n = 20;
         let smt = new_smt(pairs.clone());
-        let proof = smt.merkle_proof(pairs.iter().take(n).map(|(k, _v)| *k).collect()).expect("gen proof");
+        let proof = smt.merkle_proof(pairs.iter().take(n).map(|(k, _v)| k.clone()).collect()).expect("gen proof");
         let data: Vec<(H256, H256)> = pairs.into_iter().take(n).collect();
         let compiled_proof = proof.clone().compile(data.clone()).expect("compile proof");
         assert!(proof.verify::<Blake2bHasher>(smt.root(), data.clone()).expect("verify proof"));
@@ -437,7 +437,7 @@ proptest! {
         let smt = new_smt(pairs);
         let non_exists_keys: Vec<_> = pairs2.into_iter().map(|(k, _v)|k).collect();
         let proof = smt.merkle_proof(non_exists_keys.clone()).expect("gen proof");
-        let data: Vec<(H256, H256)> = non_exists_keys.into_iter().map(|k|(k, H256::zero())).collect();
+        let data: Vec<(H256, H256)> = non_exists_keys.into_iter().map(|k|(k, H256::empty())).collect();
         let compiled_proof = proof.clone().compile(data.clone()).expect("compile proof");
         assert!(proof.verify::<Blake2bHasher>(smt.root(), data.clone()).expect("verify proof"));
         assert!(compiled_proof.verify::<Blake2bHasher>(smt.root(), data).expect("verify compiled proof"));
@@ -453,7 +453,7 @@ proptest! {
         let mut keys: Vec<_> = exists_keys.into_iter().take(exists_keys_len).chain(non_exists_keys.into_iter().take(non_exists_keys_len)).collect();
         keys.dedup();
         let proof = smt.merkle_proof(keys.clone()).expect("gen proof");
-        let data: Vec<(H256, H256)> = keys.into_iter().map(|k|(k, smt.get(&k).expect("get"))).collect();
+        let data: Vec<(H256, H256)> = keys.into_iter().map(|k|(k.clone(), smt.get(&k).expect("get"))).collect();
         let compiled_proof = proof.clone().compile(data.clone()).expect("compile proof");
         assert!(proof.verify::<Blake2bHasher>(smt.root(), data.clone()).expect("verify proof"));
         assert!(compiled_proof.verify::<Blake2bHasher>(smt.root(), data).expect("verify compiled proof"));
@@ -470,7 +470,7 @@ proptest! {
     #[test]
     fn test_smt_random_insert_order((pairs, _n) in leaves(5, 50)){
         let smt = new_smt(pairs.clone());
-        let root = *smt.root();
+        let root = smt.root().clone();
 
         let mut pairs = pairs;
         let mut rng = rand::thread_rng();
@@ -486,11 +486,11 @@ proptest! {
             for (k, v) in &pairs {
                 assert_eq!(&smt2.get(k).unwrap(), v, "key value must be consisted");
 
-                let origin_proof = smt.merkle_proof(vec![*k]).unwrap();
-                let proof = smt2.merkle_proof(vec![*k]).unwrap();
+                let origin_proof = smt.merkle_proof(vec![k.clone()]).unwrap();
+                let proof = smt2.merkle_proof(vec![k.clone()]).unwrap();
                 assert_eq!(origin_proof, proof, "merkle proof must be consisted");
 
-                let calculated_root = proof.compute_root::<Blake2bHasher>(vec![(*k, *v)]).unwrap();
+                let calculated_root = proof.compute_root::<Blake2bHasher>(vec![(k.clone(), v.clone())]).unwrap();
                 assert_eq!(root, calculated_root, "root must be consisted");
             }
         }
@@ -501,14 +501,14 @@ proptest! {
         let mut rng = rand::thread_rng();
         let len =  rng.gen_range(0, pairs.len());
         let mut smt = new_smt(pairs[..len].to_vec());
-        let root = *smt.root();
+        let root = smt.root().clone();
 
         // insert zero values
         for (k, _v) in pairs[len..].iter() {
-            smt.update(*k, H256::zero()).unwrap();
+            smt.update(k.clone(), H256::empty()).unwrap();
         }
         // check root
-        let current_root = *smt.root();
+        let current_root = smt.root().clone();
         assert_eq!(root, current_root);
         // check inserted pairs
         for (k, v) in pairs[..len].iter() {
@@ -598,14 +598,14 @@ fn test_v0_2_broken_sample() {
     .collect::<Vec<_>>();
     let mut pairs = keys.into_iter().zip(values.into_iter()).collect::<Vec<_>>();
     let smt = new_smt(pairs.clone());
-    let base_root = *smt.root();
+    let base_root = smt.root().clone();
 
     // insert in random order
     let mut rng = rand::thread_rng();
     for _i in 0..10 {
         pairs.shuffle(&mut rng);
         let smt = new_smt(pairs.clone());
-        let current_root = *smt.root();
+        let current_root = smt.root().clone();
         assert_eq!(base_root, current_root);
     }
 }
@@ -687,14 +687,14 @@ fn test_replay_to_pass_proof() {
     ]
     .into();
     let pairs = vec![
-        (key1, existing),
-        (key2, non_existing),
-        (key3, non_existing),
-        (key4, non_existing),
+        (key1.clone(), existing),
+        (key2, non_existing.clone()),
+        (key3.clone(), non_existing.clone()),
+        (key4, non_existing.clone()),
     ];
     let smt = new_smt(pairs);
-    let leaf_a_bl = vec![(key1, H256::zero())];
-    let leaf_c = vec![(key3, non_existing)];
+    let leaf_a_bl = vec![(key1, H256::empty())];
+    let leaf_c = vec![(key3.clone(), non_existing)];
     let leaf_other = vec![(key3, other_value)];
     let proofc = smt
         .merkle_proof(leaf_c.clone().into_iter().map(|(k, _)| k).collect())
@@ -734,13 +734,13 @@ fn test_sibling_leaf() {
         H256::from(rand_data)
     }
     let rand_key = gen_rand_h256();
-    let mut sibling_key = rand_key;
+    let mut sibling_key = rand_key.clone();
     if rand_key.is_right(0) {
         sibling_key.clear_bit(0);
     } else {
         sibling_key.set_bit(0);
     }
-    let pairs = vec![(rand_key, gen_rand_h256()), (sibling_key, gen_rand_h256())];
+    let pairs = vec![(rand_key.clone(), gen_rand_h256()), (sibling_key.clone(), gen_rand_h256())];
     let keys = vec![rand_key, sibling_key];
     let smt = new_smt(pairs.clone());
     let proof = smt.merkle_proof(keys).expect("gen proof");
@@ -753,7 +753,7 @@ fn test_sibling_leaf() {
 fn test_max_stack_size() {
     fn gen_h256(height: u8) -> H256 {
         // The key path is first go right `256 - height` times then go left `height` times.
-        let mut key = H256::zero();
+        let mut key = H256::empty();
         for h in height..=255 {
             key.set_bit(h);
         }
@@ -763,10 +763,10 @@ fn test_max_stack_size() {
         .map(|height| (gen_h256(height), gen_h256(1)))
         .collect();
     // Most left key
-    pairs.push((H256::zero(), gen_h256(1)));
+    pairs.push((H256::empty(), gen_h256(1)));
     {
         // A pair of sibling keys in between
-        let mut left_key = H256::zero();
+        let mut left_key = H256::empty();
         for h in 12..56 {
             left_key.set_bit(h);
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,10 +19,10 @@ pub trait Value {
 
 impl Value for H256 {
     fn to_h256(&self) -> H256 {
-        *self
+        self.clone()
     }
     fn zero() -> Self {
-        H256::zero()
+        H256::empty()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -93,7 +93,7 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         let node = MergeValue::from_h256(value.to_h256());
         // notice when value is zero the leaf is deleted, so we do not need to store it
         if !node.is_zero() {
-            self.store.insert_leaf(key, value)?;
+            self.store.insert_leaf(key.clone(), value)?;
         } else {
             self.store.remove_leaf(&key)?;
         }
@@ -103,7 +103,7 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         let mut current_node = node;
         for height in 0..=core::u8::MAX {
             let parent_key = current_key.parent_path(height);
-            let parent_branch_key = BranchKey::new(height, parent_key);
+            let parent_branch_key = BranchKey::new(height, parent_key.clone());
             let (left, right) =
                 if let Some(parent_branch) = self.store.get_branch(&parent_branch_key)? {
                     if current_key.is_right(height) {
@@ -131,7 +131,7 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
                 self.store.remove_branch(&parent_branch_key)?;
             }
             // prepare for next round
-            current_key = parent_key;
+            current_key = parent_key.clone();
             current_node = merge::<H>(height, &parent_key, &left, &right);
         }
 
@@ -160,7 +160,7 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         // Collect leaf bitmaps
         let mut leaves_bitmap: Vec<H256> = Default::default();
         for current_key in &keys {
-            let mut bitmap = H256::zero();
+            let mut bitmap = H256::empty();
             for height in 0..=core::u8::MAX {
                 let parent_key = current_key.parent_path(height);
                 let parent_branch_key = BranchKey::new(height, parent_key);
@@ -185,7 +185,7 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         let mut stack_top = 0;
         let mut leaf_index = 0;
         while leaf_index < keys.len() {
-            let leaf_key = keys[leaf_index];
+            let leaf_key = keys[leaf_index].clone();
             let fork_height = if leaf_index + 1 < keys.len() {
                 leaf_key.fork_height(&keys[leaf_index + 1])
             } else {


### PR DESCRIPTION
I replaced the native H256 with the one in Rust-numext。