### PR TITLE
chore(pref): tweak update-all fn

### DIFF
--- a/benches/smt_benchmark.rs
+++ b/benches/smt_benchmark.rs
@@ -30,6 +30,17 @@ fn random_smt(update_count: usize, rng: &mut impl Rng) -> (SMT, Vec<H256>) {
     (smt, keys)
 }
 
+fn random_smt_update_all(update_count: usize, rng: &mut impl Rng) {
+    let mut smt = SMT::default();
+    let mut kvs = Vec::with_capacity(update_count);
+    for _ in 0..update_count {
+        let key = random_h256(rng);
+        let value = random_h256(rng);
+        kvs.push((key, value));
+    }
+    smt.update_all(kvs).unwrap();
+}
+
 fn bench(c: &mut Criterion) {
     c.bench_function_over_inputs(
         "SMT update",
@@ -37,6 +48,17 @@ fn bench(c: &mut Criterion) {
             b.iter(|| {
                 let mut rng = thread_rng();
                 random_smt(size, &mut rng)
+            });
+        },
+        &[100, 10_000],
+    );
+
+    c.bench_function_over_inputs(
+        "SMT update_all",
+        |b, &&size| {
+            b.iter(|| {
+                let mut rng = thread_rng();
+                random_smt_update_all(size, &mut rng)
             });
         },
         &[100, 10_000],

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,5 @@
 use crate::{
+    collections::VecDeque,
     error::{Error, Result},
     merge::{merge, MergeValue},
     merkle_proof::MerkleProof,
@@ -146,73 +147,77 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         leaves.sort_by_key(|(a, _)| *a);
         leaves.dedup_by_key(|(a, _)| *a);
 
-        let mut nodes: Vec<(H256, MergeValue)> = Vec::new();
-        for (k, v) in leaves {
-            let value = MergeValue::from_h256(v.to_h256());
-            if !value.is_zero() {
-                self.store.insert_leaf(k, v)?;
-            } else {
-                self.store.remove_leaf(&k)?;
-            }
-            nodes.push((k, value));
-        }
+        let mut nodes = leaves
+            .into_iter()
+            .map(|(k, v)| {
+                let value = MergeValue::from_h256(v.to_h256());
+                if !value.is_zero() {
+                    self.store.insert_leaf(k, v)
+                } else {
+                    self.store.remove_leaf(&k)
+                }
+                .map(|_| (k, value, 0))
+            })
+            .collect::<Result<VecDeque<(H256, MergeValue, u8)>>>()?;
 
-        for height in 0..=core::u8::MAX {
-            let mut next_nodes: Vec<(H256, MergeValue)> = Vec::new();
-            let mut i = 0;
-            while i < nodes.len() {
-                let (current_key, current_merge_value) = &nodes[i];
-                i += 1;
-                let parent_key = current_key.parent_path(height);
-                let parent_branch_key = BranchKey::new(height, parent_key);
+        while let Some((current_key, current_merge_value, height)) = nodes.pop_front() {
+            let parent_key = current_key.parent_path(height);
+            let parent_branch_key = BranchKey::new(height, parent_key);
 
-                // Test for neighbors
-                let mut right = None;
-                if i < nodes.len() && (!current_key.is_right(height)) {
-                    let (neighbor_key, neighbor_value) = &nodes[i];
-                    let mut right_key = *current_key;
+            // Test for neighbors
+            let mut right = None;
+            if !current_key.is_right(height) && !nodes.is_empty() {
+                let (neighbor_key, _, neighbor_height) = nodes.front().expect("nodes is not empty");
+                if neighbor_height.eq(&height) {
+                    let mut right_key = current_key;
                     right_key.set_bit(height);
-                    if right_key == *neighbor_key {
-                        right = Some(neighbor_value.clone());
-                        i += 1;
+                    if neighbor_key.eq(&right_key) {
+                        let (_, neighbor_value, _) = nodes.pop_front().expect("nodes is not empty");
+                        right = Some(neighbor_value);
                     }
                 }
-
-                let (left, right) = if let Some(right_merge_value) = right {
-                    (current_merge_value.clone(), right_merge_value)
-                } else {
-                    // In case neighbor is not available, fetch from store
-                    if let Some(parent_branch) = self.store.get_branch(&parent_branch_key)? {
-                        if current_key.is_right(height) {
-                            (parent_branch.left, current_merge_value.clone())
-                        } else {
-                            (current_merge_value.clone(), parent_branch.right)
-                        }
-                    } else if current_key.is_right(height) {
-                        (MergeValue::zero(), current_merge_value.clone())
-                    } else {
-                        (current_merge_value.clone(), MergeValue::zero())
-                    }
-                };
-
-                if !left.is_zero() || !right.is_zero() {
-                    self.store.insert_branch(
-                        parent_branch_key,
-                        BranchNode {
-                            left: left.clone(),
-                            right: right.clone(),
-                        },
-                    )?;
-                } else {
-                    self.store.remove_branch(&parent_branch_key)?;
-                }
-                next_nodes.push((parent_key, merge::<H>(height, &parent_key, &left, &right)));
             }
-            nodes = next_nodes;
+
+            let (left, right) = if let Some(right_merge_value) = right {
+                (current_merge_value.clone(), right_merge_value)
+            } else {
+                // In case neighbor is not available, fetch from store
+                if let Some(parent_branch) = self.store.get_branch(&parent_branch_key)? {
+                    if current_key.is_right(height) {
+                        (parent_branch.left, current_merge_value.clone())
+                    } else {
+                        (current_merge_value.clone(), parent_branch.right)
+                    }
+                } else if current_key.is_right(height) {
+                    (MergeValue::zero(), current_merge_value.clone())
+                } else {
+                    (current_merge_value.clone(), MergeValue::zero())
+                }
+            };
+
+            if !left.is_zero() || !right.is_zero() {
+                self.store.insert_branch(
+                    parent_branch_key,
+                    BranchNode {
+                        left: left.clone(),
+                        right: right.clone(),
+                    },
+                )?;
+            } else {
+                self.store.remove_branch(&parent_branch_key)?;
+            }
+            if height == core::u8::MAX {
+                self.root = merge::<H>(height, &parent_key, &left, &right).hash::<H>();
+                break;
+            } else {
+                nodes.push_back((
+                    parent_key,
+                    merge::<H>(height, &parent_key, &left, &right),
+                    height + 1,
+                ));
+            }
         }
 
-        assert!(nodes.len() == 1);
-        self.root = nodes[0].1.hash::<H>();
         Ok(&self.root)
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -179,19 +179,19 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
             }
 
             let (left, right) = if let Some(right_merge_value) = right {
-                (current_merge_value.clone(), right_merge_value)
+                (current_merge_value, right_merge_value)
             } else {
                 // In case neighbor is not available, fetch from store
                 if let Some(parent_branch) = self.store.get_branch(&parent_branch_key)? {
                     if current_key.is_right(height) {
-                        (parent_branch.left, current_merge_value.clone())
+                        (parent_branch.left, current_merge_value)
                     } else {
-                        (current_merge_value.clone(), parent_branch.right)
+                        (current_merge_value, parent_branch.right)
                     }
                 } else if current_key.is_right(height) {
-                    (MergeValue::zero(), current_merge_value.clone())
+                    (MergeValue::zero(), current_merge_value)
                 } else {
-                    (current_merge_value.clone(), MergeValue::zero())
+                    (current_merge_value, MergeValue::zero())
                 }
             };
 


### PR DESCRIPTION
This PR use `VecDeque` to replace the loop/counter in `update_all` fn, bench result:
```
SMT update_all/100      time:   [5.6711 ms 5.7154 ms 5.7527 ms]                              
                        change: [-29.149% -20.135% -9.3439%] (p = 0.00 < 0.05)
                        Performance has improved.
SMT update_all/10000    time:   [1.2788 s 1.2899 s 1.3054 s]                                  
                        change: [-11.465% -7.1029% -3.0761%] (p = 0.01 < 0.05)
                        Performance has improved.
```