### PR TITLE
refactor: split `Store` trait into small ones

### DIFF
--- a/src/default_store.rs
+++ b/src/default_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     collections,
     error::Error,
-    traits::Store,
+    traits::{StoreReadOps, StoreWriteOps},
     tree::{BranchKey, BranchNode},
     H256,
 };
@@ -25,13 +25,16 @@ impl<V> DefaultStore<V> {
     }
 }
 
-impl<V: Clone> Store<V> for DefaultStore<V> {
+impl<V: Clone> StoreReadOps<V> for DefaultStore<V> {
     fn get_branch(&self, branch_key: &BranchKey) -> Result<Option<BranchNode>, Error> {
         Ok(self.branches_map.get(branch_key).map(Clone::clone))
     }
     fn get_leaf(&self, leaf_key: &H256) -> Result<Option<V>, Error> {
         Ok(self.leaves_map.get(leaf_key).map(Clone::clone))
     }
+}
+
+impl<V> StoreWriteOps<V> for DefaultStore<V> {
     fn insert_branch(&mut self, branch_key: BranchKey, branch: BranchNode) -> Result<(), Error> {
         self.branches_map.insert(branch_key, branch);
         Ok(())

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -398,7 +398,7 @@ proptest! {
     #[test]
     fn test_smt_single_leaf_small((pairs, _n) in leaves(1, 50)){
         let smt = new_smt(pairs.clone());
-        for (k, v) in pairs.clone() {
+        for (k, v) in pairs {
             let proof = smt.merkle_proof(vec![k]).expect("gen proof");
             let compiled_proof = proof.clone().compile(vec![k]).expect("compile proof");
             assert!(proof.verify::<Blake2bHasher>(smt.root(), vec![(k, v)]).expect("verify proof"));

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,10 +26,13 @@ impl Value for H256 {
     }
 }
 
-/// Trait for customize backend storage
-pub trait Store<V> {
+/// Traits for customize backend storage
+pub trait StoreReadOps<V> {
     fn get_branch(&self, branch_key: &BranchKey) -> Result<Option<BranchNode>, Error>;
     fn get_leaf(&self, leaf_key: &H256) -> Result<Option<V>, Error>;
+}
+
+pub trait StoreWriteOps<V> {
     fn insert_branch(&mut self, node_key: BranchKey, branch: BranchNode) -> Result<(), Error>;
     fn insert_leaf(&mut self, leaf_key: H256, leaf: V) -> Result<(), Error>;
     fn remove_branch(&mut self, node_key: &BranchKey) -> Result<(), Error>;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{Error, Result},
     merge::{merge, MergeValue},
     merkle_proof::MerkleProof,
-    traits::{Hasher, Store, Value},
+    traits::{Hasher, StoreReadOps, StoreWriteOps, Value},
     vec::Vec,
     H256, MAX_STACK_SIZE,
 };
@@ -52,7 +52,7 @@ pub struct SparseMerkleTree<H, V, S> {
     phantom: PhantomData<(H, V)>,
 }
 
-impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
+impl<H, V, S> SparseMerkleTree<H, V, S> {
     /// Build a merkle tree from root and store
     pub fn new(root: H256, store: S) -> SparseMerkleTree<H, V, S> {
         SparseMerkleTree {
@@ -86,7 +86,11 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
     pub fn store_mut(&mut self) -> &mut S {
         &mut self.store
     }
+}
 
+impl<H: Hasher + Default, V: Value, S: StoreReadOps<V> + StoreWriteOps<V>>
+    SparseMerkleTree<H, V, S>
+{
     /// Update a leaf, return new merkle root
     /// set to zero value to delete a key
     pub fn update(&mut self, key: H256, value: V) -> Result<&H256> {
@@ -220,7 +224,9 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
 
         Ok(&self.root)
     }
+}
 
+impl<H: Hasher + Default, V: Value, S: StoreReadOps<V>> SparseMerkleTree<H, V, S> {
     /// Get value of a leaf
     /// return zero value if leaf not exists
     pub fn get(&self, key: &H256) -> Result<V> {


### PR DESCRIPTION
To facilitate the implementation of different behaviors of the store, this PR splits the `Store` trait into `StoreReadOps` and `StoreWriteOps`, for example, a readonly store implementation which only provide the merkle proof generation service may only need to impl the `StoreReadOps`.

example usage: https://github.com/quake/smt-rocksdb-store

notes: this PR is a minor breaking change for other crates which has impl the `Store` trait with old version.