### PR TITLE
feat: load root from store

### DIFF
--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -494,6 +494,13 @@ proptest! {
     }
 
     #[test]
+    fn test_from_store((pairs, _n) in leaves(1, 20)) {
+        let smt = new_smt(pairs.clone());
+        let smt2 = SMT::new_with_store(smt.store().clone()).expect("from store");
+        assert_eq!(smt.root(), smt2.root());
+    }
+
+    #[test]
     fn test_smt_update_all((pairs, _n) in leaves(1, 20), (pairs2, _n2) in leaves(1, 10)){
         let mut smt = new_smt(pairs.clone());
         for (k, v) in pairs2.clone().into_iter() {


### PR DESCRIPTION
In the current code we need to store the root in an extra place in order to build the tree from the store, for example:

1. https://github.com/godwokenrises/godwoken/blob/ad898e7a9821df3e627737d32865bec85bf1a753/crates/store/src/mem_pool_state.rs#L105-L112

2. https://github.com/quake/smt-rocksdb-store/blob/d265fbddbf26c7808619d3a21d5a8d9f66d31c56/examples/rpc_server_multi_tree.rs#L93-L96

But actually the root can be loaded and computed automatically by loading store root branch, this PR added a new fn `new_with_store` to resolve this issue


