### PR TITLE
Support switching blake2b-rs and blake2b-ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,18 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "use-blake2b-rs"]
 std = []
 # SMT implemented in C
 smtc = []
 # A storage optimized SMT implemented in trie (https://ouvrard-pierre-alain.medium.com/sparse-merkle-tree-86e6e2fc26da)
 trie = []
+use-blake2b-rs = ["blake2b-rs"]
 
 [dependencies]
 cfg-if = "1"
-blake2b-rs = "0.2"
+blake2b-rs = {version = "0.2", optional = true }
+blake2b-ref = "0.3.1"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,19 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "use-blake2b-rs"]
+default = ["std", "with-blake2b-rs"]
 std = []
 # SMT implemented in C
 smtc = []
 # A storage optimized SMT implemented in trie (https://ouvrard-pierre-alain.medium.com/sparse-merkle-tree-86e6e2fc26da)
 trie = []
-use-blake2b-rs = ["blake2b-rs"]
+with-blake2b-rs = ["dep:blake2b-rs"]
+with-blake2b-ref = ["dep:blake2b-ref"]
 
 [dependencies]
 cfg-if = "1"
-blake2b-rs = {version = "0.2", optional = true }
-blake2b-ref = "0.3.1"
+blake2b-rs = { version = "0.2", optional = true }
+blake2b-ref = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 proptest = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ bench-test-trie:
 	cargo bench --features trie -- --test
 
 clippy:
-	cargo clippy  --all --features std,smtc --all-targets
+	cargo clippy  --all --features std,smtc,with-blake2b-rs --all-targets
 
 clippy-trie:
 	cargo clippy  --all --all-features --all-targets
@@ -22,7 +22,7 @@ fmt:
 	cargo fmt --all -- --check
 
 check:
-	cargo check --no-default-features
+	cargo check --no-default-features --features with-blake2b-rs
 
 test-c-impl:
 	git submodule update --init --recursive
@@ -32,4 +32,4 @@ test-cxx-build:
 	g++ -c src/ckb_smt.c -I c -o smt.o && rm -rf smt.o
 
 test-blake2b-ref:
-	cargo test --no-default-features --features="std"
+	cargo test --no-default-features --features="std","with-blake2b-ref"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: fmt clippy clippy-trie test test-trie bench-test bench-test-trie check test-c-impl test-cxx-build
+default: fmt clippy clippy-trie test test-trie bench-test bench-test-trie check test-c-impl test-cxx-build test-blake2b-ref
 
 test:
 	cargo test --all --features std,smtc
@@ -30,3 +30,6 @@ test-c-impl:
 
 test-cxx-build:
 	g++ -c src/ckb_smt.c -I c -o smt.o && rm -rf smt.o
+
+test-blake2b-ref:
+	cargo test --no-default-features --features="std"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ height:
 
 The above graph demonstrates a sparse merkle tree with `2 ^ 256` leaves, which can mapping every possible `H256` value into leaves. The height of the tree is `256`, from top to bottom, we denote `0` for each left branch and denote `1` for each right branch, so we can get a 256 bits path, which also can represent in `H256`, we use the path as the key of leaves, the most left leaf's key is `0x00..00`, and the next key is `0x00..01`, the most right key is `0x11..11`.
 
+## Blake2b-rs or Blake2b-ref
+
+`Blake2b-rs` uses a C backend and generally offers higher performance, while `Blake2b-ref` is a pure Rust implementation that tends to provide better portability and compatibility.
+
+**Feature flag:** `use-blake2b-rs` (enabled by default).
+When this feature is enabled, the crate uses `Blake2b-rs`. If you disable `use-blake2b-rs`, it falls back to `Blake2b-ref`.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ The above graph demonstrates a sparse merkle tree with `2 ^ 256` leaves, which c
 
 `Blake2b-rs` uses a C backend and generally offers higher performance, while `Blake2b-ref` is a pure Rust implementation that tends to provide better portability and compatibility.
 
-**Feature flag:** `use-blake2b-rs` (enabled by default).
-When this feature is enabled, the crate uses `Blake2b-rs`. If you disable `use-blake2b-rs`, it falls back to `Blake2b-ref`.
+**Features**
+
+* `with-blake2b-rs` (enabled by default): uses the Blake2b-rs backend.
+* `with-blake2b-ref`: uses the Blake2b-ref backend.
+* If both features are enabled, **Blake2b-rs takes precedence** (to prevent build issues when both are accidentally turned on).
+* If enable `no-default-features`, **must explicitly enable exactly one** of the above features.
 
 ## License
 

--- a/c/rust-tests/Cargo.toml
+++ b/c/rust-tests/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 sparse-merkle-tree = { path = "../../" }
-blake2b-rs = "0.2"
 proptest = "0.9"
 criterion = "0.2"
 rand = "0.7"

--- a/c/rust-tests/src/tests/smt.rs
+++ b/c/rust-tests/src/tests/smt.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use anyhow::Result as AnyResult;
-use blake2b_rs::{Blake2b, Blake2bBuilder};
 use core::ffi::c_void;
 use proptest::prelude::*;
 use rand::prelude::Rng;
 use serde::{Deserialize, Serialize};
+use sparse_merkle_tree::blake2b::{Blake2b, Blake2bBuilder};
 use sparse_merkle_tree::traits::Hasher;
 use sparse_merkle_tree::{default_store::DefaultStore, SparseMerkleTree, H256};
 use std::collections::HashMap;
@@ -249,12 +249,9 @@ fn run_test_case(case: Case) -> AnyResult<()> {
                 return Ok(());
             }
         };
-        let ckb_actual_compiled_proof = ckb_actual_proof.clone().compile(
-            leaves
-                .iter()
-                .map(|(k, _v)| (*k).into())
-                .collect(),
-        )?;
+        let ckb_actual_compiled_proof = ckb_actual_proof
+            .clone()
+            .compile(leaves.iter().map(|(k, _v)| (*k).into()).collect())?;
         let ckb_actual_compiled_proof_bin: Vec<u8> = ckb_actual_compiled_proof.clone().into();
 
         let mut smt_state = SmtCImpl::new(leaves.len() as u32);
@@ -285,9 +282,12 @@ fn hex2bin(src: String) -> Vec<u8> {
 
 #[test]
 fn test_smt_c_verify1() {
-    let key = hex2bin("381dc5391dab099da5e28acd1ad859a051cf18ace804d037f12819c6fbc0e18b".to_owned());
-    let value = hex2bin("9158ce9b0e11dd150ba2ae5d55c1db04b1c5986ec626f2e38a93fe8ad0b2923b".to_owned());
-    let root_hash = hex2bin("ebe0fab376cd802d364eeb44af20c67a74d6183a33928fead163120ef12e6e06".to_owned());
+    let key =
+        hex2bin("381dc5391dab099da5e28acd1ad859a051cf18ace804d037f12819c6fbc0e18b".to_owned());
+    let value =
+        hex2bin("9158ce9b0e11dd150ba2ae5d55c1db04b1c5986ec626f2e38a93fe8ad0b2923b".to_owned());
+    let root_hash =
+        hex2bin("ebe0fab376cd802d364eeb44af20c67a74d6183a33928fead163120ef12e6e06".to_owned());
     let proof = hex2bin(
         "4c4fff51ff322de8a89fe589987f97220cfcb6820bd798b31a0b56ffea221093d35f909e580b00000000000000000000000000000000000000000000000000000000000000".to_owned());
 
@@ -296,16 +296,24 @@ fn test_smt_c_verify1() {
         smt_state_insert(changes, key.as_ptr(), value.as_ptr());
         smt_state_normalize(changes);
 
-        let verify_ref = smt_verify(root_hash.as_ptr(), changes, proof.as_ptr(), proof.len() as u32);
+        let verify_ref = smt_verify(
+            root_hash.as_ptr(),
+            changes,
+            proof.as_ptr(),
+            proof.len() as u32,
+        );
         assert_eq!(0, verify_ref);
     }
 }
 
 #[test]
 fn test_smt_c_verify2() {
-    let key = hex2bin("a9bb945be71f0bd2757d33d2465b6387383da42f321072e47472f0c9c7428a8a".to_owned());
-    let value = hex2bin("a939a47335f777eac4c40fbc0970e25f832a24e1d55adc45a7b76d63fe364e82".to_owned());
-    let root_hash = hex2bin("6e5c722644cd55cef8c4ed886cd8b44027ae9ed129e70a4b67d87be1c6857842".to_owned());
+    let key =
+        hex2bin("a9bb945be71f0bd2757d33d2465b6387383da42f321072e47472f0c9c7428a8a".to_owned());
+    let value =
+        hex2bin("a939a47335f777eac4c40fbc0970e25f832a24e1d55adc45a7b76d63fe364e82".to_owned());
+    let root_hash =
+        hex2bin("6e5c722644cd55cef8c4ed886cd8b44027ae9ed129e70a4b67d87be1c6857842".to_owned());
     let proof = hex2bin(
         "4c4fff51fa8aaa2aece17b92ec3f202a40a09f7286522bae1e5581a2a49195ab6781b1b8090000000000000000000000000000000000000000000000000000000000000000".to_owned());
 
@@ -314,7 +322,12 @@ fn test_smt_c_verify2() {
         smt_state_insert(changes, key.as_ptr(), value.as_ptr());
         smt_state_normalize(changes);
 
-        let verify_ref = smt_verify(root_hash.as_ptr(), changes, proof.as_ptr(), proof.len() as u32);
+        let verify_ref = smt_verify(
+            root_hash.as_ptr(),
+            changes,
+            proof.as_ptr(),
+            proof.len() as u32,
+        );
         assert_eq!(0, verify_ref);
     }
 }

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -1,5 +1,12 @@
 use crate::{traits::Hasher, H256};
-use blake2b_rs::{Blake2b, Blake2bBuilder};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "use-blake2b-rs")] {
+        pub use blake2b_rs::{Blake2b, Blake2bBuilder};
+    } else {
+        pub use blake2b_ref::{Blake2b, Blake2bBuilder};
+    }
+}
 
 const BLAKE2B_KEY: &[u8] = &[];
 const BLAKE2B_LEN: usize = 32;

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -1,9 +1,9 @@
 use crate::{traits::Hasher, H256};
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "use-blake2b-rs")] {
+    if #[cfg(feature = "with-blake2b-rs")] {
         pub use blake2b_rs::{Blake2b, Blake2bBuilder};
-    } else {
+    } else if #[cfg(feature = "with-blake2b-ref")] {
         pub use blake2b_ref::{Blake2b, Blake2bBuilder};
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,10 @@
 //!
 //! ```
 //! use sparse_merkle_tree::{
-//!     blake2b::Blake2bHasher, default_store::DefaultStore,
+//!     blake2b::{Blake2bHasher, Blake2b, Blake2bBuilder}, default_store::DefaultStore,
 //!     error::Error, MerkleProof,
 //!     SparseMerkleTree, traits::Value, H256
 //! };
-//! use blake2b_rs::{Blake2b, Blake2bBuilder};
 //!
 //! // define SMT
 //! type SMT = SparseMerkleTree<Blake2bHasher, Word, DefaultStore<Word>>;

--- a/src/tests/smt.rs
+++ b/src/tests/smt.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "smtc")]
 use std::convert::TryInto;
 
+use crate::blake2b::{Blake2b, Blake2bBuilder};
 use crate::*;
-use blake2b_rs::{Blake2b, Blake2bBuilder};
 use default_store::DefaultStore;
 #[cfg(feature = "smtc")]
 use hex::decode;

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -68,8 +68,10 @@ fn test_default_merkle_proof() {
 
 #[test]
 fn test_merkle_root() {
-    fn new_blake2b() -> blake2b_rs::Blake2b {
-        blake2b_rs::Blake2bBuilder::new(32).personal(b"SMT").build()
+    fn new_blake2b() -> crate::blake2b::Blake2b {
+        crate::blake2b::Blake2bBuilder::new(32)
+            .personal(b"SMT")
+            .build()
     }
 
     let mut tree = SMT::default();


### PR DESCRIPTION
`Blake2b-rs` uses a C backend and generally offers higher performance, while `Blake2b-ref` is a pure Rust implementation that tends to provide better portability and compatibility.

**Feature flag:** `use-blake2b-rs` (enabled by default).
When this feature is enabled, the crate uses `Blake2b-rs`. If you disable `use-blake2b-rs`, it falls back to `Blake2b-ref`.
