### PR TITLE
chore: fix clippy issues

### DIFF
--- a/benches/store_counter_benchmark.rs
+++ b/benches/store_counter_benchmark.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate criterion;
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/ckb_smt.rs
+++ b/src/ckb_smt.rs
@@ -61,7 +61,7 @@ impl SMTBuilder {
                 len: 0,
                 capacity: 0,
             }),
-            _buffer: Vec::with_capacity(capacity as usize),
+            _buffer: Vec::with_capacity(capacity),
         };
         unsafe {
             smt_state_init(smt.state.as_mut(), smt._buffer.as_ptr(), capacity as u32);

--- a/src/default_store.rs
+++ b/src/default_store.rs
@@ -27,10 +27,10 @@ impl<V> DefaultStore<V> {
 
 impl<V: Clone> StoreReadOps<V> for DefaultStore<V> {
     fn get_branch(&self, branch_key: &BranchKey) -> Result<Option<BranchNode>, Error> {
-        Ok(self.branches_map.get(branch_key).map(Clone::clone))
+        Ok(self.branches_map.get(branch_key).cloned())
     }
     fn get_leaf(&self, leaf_key: &H256) -> Result<Option<V>, Error> {
-        Ok(self.leaves_map.get(leaf_key).map(Clone::clone))
+        Ok(self.leaves_map.get(leaf_key).cloned())
     }
 }
 

--- a/src/h256.rs
+++ b/src/h256.rs
@@ -20,7 +20,7 @@ impl H256 {
     pub fn get_bit(&self, i: u8) -> bool {
         let byte_pos = i / BYTE_SIZE;
         let bit_pos = i % BYTE_SIZE;
-        let bit = self.0[byte_pos as usize] >> bit_pos & 1;
+        let bit = (self.0[byte_pos as usize] >> bit_pos) & 1;
         bit != 0
     }
 
@@ -28,7 +28,7 @@ impl H256 {
     pub fn set_bit(&mut self, i: u8) {
         let byte_pos = i / BYTE_SIZE;
         let bit_pos = i % BYTE_SIZE;
-        self.0[byte_pos as usize] |= 1 << bit_pos as u8;
+        self.0[byte_pos as usize] |= 1 << bit_pos;
     }
 
     #[inline]
@@ -50,7 +50,7 @@ impl H256 {
     /// Treat H256 as a path in a tree
     /// fork height is the number of common bits(from heigher to lower: 255..=0) of two H256
     pub fn fork_height(&self, key: &H256) -> u8 {
-        for h in (0..=core::u8::MAX).rev() {
+        for h in (0..=u8::MAX).rev() {
             if self.get_bit(h) != key.get_bit(h) {
                 return h;
             }
@@ -61,7 +61,7 @@ impl H256 {
     /// Treat H256 as a path in a tree
     /// return parent_path of self
     pub fn parent_path(&self, height: u8) -> Self {
-        if height == core::u8::MAX {
+        if height == u8::MAX {
             H256::zero()
         } else {
             self.copy_bits(height + 1)

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -86,7 +86,7 @@ pub fn into_merge_value<H: Hasher + Default>(key: H256, value: H256, height: u8)
         let base_key = key.parent_path(0);
         let base_node = hash_base_node::<H>(0, &base_key, &value);
         let mut zero_bits = key;
-        for i in height..=core::u8::MAX {
+        for i in height..=u8::MAX {
             if key.get_bit(i) {
                 zero_bits.clear_bit(i);
             }
@@ -175,7 +175,7 @@ pub fn merge_with_zero<H: Hasher + Default>(
         }
         #[cfg(feature = "trie")]
         MergeValue::ShortCut { key, value, .. } => {
-            if height == core::u8::MAX {
+            if height == u8::MAX {
                 let base_key = key.parent_path(0);
                 let base_node = hash_base_node::<H>(0, &base_key, value);
                 MergeValue::MergeWithZero {

--- a/src/merkle_proof.rs
+++ b/src/merkle_proof.rs
@@ -73,7 +73,7 @@ impl MerkleProof {
             let fork_height = if leaf_index + 1 < leaves_keys.len() {
                 leaf_key.fork_height(&leaves_keys[leaf_index + 1])
             } else {
-                core::u8::MAX
+                u8::MAX
             };
             proof.push(0x4C);
             let mut zero_count = 0u16;

--- a/src/tests/fixtures.rs
+++ b/src/tests/fixtures.rs
@@ -25,10 +25,10 @@ struct Case {
     proofs: Vec<Proof>,
 }
 
-type SMT = SparseMerkleTree<Blake2bHasher, H256, DefaultStore<H256>>;
+type Smt = SparseMerkleTree<Blake2bHasher, H256, DefaultStore<H256>>;
 
-fn new_smt(pairs: Vec<(H256, H256)>) -> SMT {
-    let mut smt = SMT::default();
+fn new_smt(pairs: Vec<(H256, H256)>) -> Smt {
+    let mut smt = Smt::default();
     for (key, value) in pairs {
         smt.update(key, value).unwrap();
     }

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -379,7 +379,7 @@ proptest! {
     fn test_h256_copy_bits(start: u8) {
         let one: H256 = [255u8; 32].into();
         let target = one.copy_bits(start);
-        for i in start..=core::u8::MAX {
+        for i in start..=u8::MAX {
             assert_eq!(one.get_bit(i), target.get_bit(i));
         }
         for i in 0..start {
@@ -793,7 +793,7 @@ fn test_trie_broken_sample_02() {
         .compute_root::<Blake2bHasher>(
             kv_state
                 .iter()
-                .map(|(k, v)| (k.clone().into(), v.clone().into()))
+                .map(|(k, v)| ((*k).into(), (*v).into()))
                 .collect(),
         )
         .unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,3 +1,4 @@
+// TODO:
 #![allow(dead_code)]
 
 use crate::{
@@ -61,7 +62,7 @@ impl BranchNode {
 }
 
 /// Sparse merkle tree
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SparseMerkleTree<H, V, S> {
     store: S,
     root: H256,

--- a/src/trie_tree.rs
+++ b/src/trie_tree.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::{
     error::{Error, Result},
     merge::{into_merge_value, merge, MergeValue},
@@ -56,14 +58,12 @@ impl<H, V, S> SparseMerkleTree<H, V, S> {
 impl<H: Hasher + Default, V, S: StoreReadOps<V>> SparseMerkleTree<H, V, S> {
     /// Build a merkle tree from store, the root will be calculated automatically
     pub fn new_with_store(store: S) -> Result<SparseMerkleTree<H, V, S>> {
-        let root_branch_key = BranchKey::new(core::u8::MAX, H256::zero());
+        let root_branch_key = BranchKey::new(u8::MAX, H256::zero());
         store
             .get_branch(&root_branch_key)
             .map(|branch_node| {
                 branch_node
-                    .map(|n| {
-                        merge::<H>(core::u8::MAX, &H256::zero(), &n.left, &n.right).hash::<H>()
-                    })
+                    .map(|n| merge::<H>(u8::MAX, &H256::zero(), &n.left, &n.right).hash::<H>())
                     .unwrap_or_default()
             })
             .map(|root| SparseMerkleTree::new(root, store))
@@ -85,7 +85,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V> + StoreWriteOps<V>>
             self.store.insert_leaf(key, value)?;
         }
 
-        let mut last_height = core::u8::MAX;
+        let mut last_height = u8::MAX;
         loop {
             // walk from top to bottom
             let node_key = key.parent_path(last_height);
@@ -199,7 +199,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V> + StoreWriteOps<V>>
             }
         }
 
-        for height in last_height..=core::u8::MAX {
+        for height in last_height..=u8::MAX {
             // update tree hash from insert pos to top
             let node_key = key.parent_path(height);
             let branch_key = BranchKey::new(height, node_key);
@@ -209,7 +209,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V> + StoreWriteOps<V>>
             } else {
                 MergeValue::zero()
             };
-            if height == core::u8::MAX {
+            if height == u8::MAX {
                 // updating root
                 self.root = new_merge.hash::<H>();
             } else {
@@ -292,7 +292,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V>> SparseMerkleTree<H, V, S
         let mut leaves_bitmap: Vec<H256> = Default::default();
         for current_key in &keys {
             let mut bitmap = H256::zero();
-            for height in (0..=core::u8::MAX).rev() {
+            for height in (0..=u8::MAX).rev() {
                 let parent_key = current_key.parent_path(height);
                 let parent_branch_key = BranchKey::new(height, parent_key);
                 if let Some(parent_branch) = self.store.get_branch(&parent_branch_key)? {
@@ -327,11 +327,10 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V>> SparseMerkleTree<H, V, S
             let fork_height = if leaf_index + 1 < keys.len() {
                 leaf_key.fork_height(&keys[leaf_index + 1])
             } else {
-                core::u8::MAX
+                u8::MAX
             };
 
             let heights = (0..=fork_height)
-                .into_iter()
                 .filter(|height| {
                     if stack_top > 0 && stack_fork_height[stack_top - 1] == *height {
                         stack_top -= 1;
@@ -378,7 +377,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V>> SparseMerkleTree<H, V, S
                         }
                     } else {
                         // Maybe we've skipped shortcut node, find from up to down
-                        for i in (height..=core::u8::MAX).rev() {
+                        for i in (height..=u8::MAX).rev() {
                             let parent_key = leaf_key.parent_path(i);
                             let is_right = leaf_key.is_right(i);
                             let parent_branch_key = BranchKey::new(i, parent_key);

--- a/src/trie_tree.rs
+++ b/src/trie_tree.rs
@@ -1,3 +1,4 @@
+// TODO:
 #![allow(dead_code)]
 
 use crate::{


### PR DESCRIPTION
The `#![allow(dead_code)]` in `tree.rs` and `tree_trie.rs` should be resolved in other PR. It is complicated.